### PR TITLE
rock-browse: avoid rendering top level items

### DIFF
--- a/lib/rock/browse/main.rb
+++ b/lib/rock/browse/main.rb
@@ -64,7 +64,7 @@ class Main < Qt::Widget
         end
 
         view.connect(SIGNAL('itemClicked(QTreeWidgetItem*,int)')) do |item, col|
-            if item
+            if item and not item.parent.nil?
                 render_item(item)
             end
         end


### PR DESCRIPTION
clicking on a top level item leads to an exception currently