### PR TITLE
Make rock-bundle-sel robust to changes of the logging level

### DIFF
--- a/shell/bash
+++ b/shell/bash
@@ -14,6 +14,7 @@ function rock-bundle-sel() {
         echo "cannot find bundle $name, run bundle-info to get the list of available bundles"
         return 1
     elif test -z "$name" || test -d "$name"; then
+        bundle_path=$(echo $bundle_path | tail -n1)
         export ROCK_BUNDLE=$bundle_path
         rock-bundle-info
         return 0

--- a/shell/sh
+++ b/shell/sh
@@ -14,6 +14,7 @@ __rock_bundle_sel() {
         echo "cannot find bundle $name, run bundle-info to get the list of available bundles"
         return 1
     elif test -z "$name" || test -d "$name"; then
+        bundle_path=$(echo $bundle_path | tail -n1)
         export ROCK_BUNDLE=$bundle_path
         rock-bundle-info
         return 0

--- a/shell/zsh
+++ b/shell/zsh
@@ -14,6 +14,7 @@ function rock-bundle-sel() {
         echo "cannot find bundle $name, run bundle-info to get the list of available bundles"
         return 1
     elif test -z "$name" || test -d "$name"; then
+        bundle_path=$(echo $bundle_path | tail -n1)
         export ROCK_BUNDLE=$bundle_path
         rock-bundle-info
         return 0


### PR DESCRIPTION
This makes sure that only the bundle path is picked up for setting the ROCK_BUNDLE env variable

```ruby
$ rock-bundle-find rock
OroGen[INFO]: loading plugin /opt/workspace/transterra/dev/install/share/orogen/plugins/orogen_metadata.rb
OroGen[INFO]: loading plugin /opt/workspace/transterra/dev/install/share/orogen/plugins/transformer_plugin.rb
OroGen[INFO]: loading plugin /opt/workspace/transterra/dev/install/share/orogen/plugins/aggregator_plugin.rb
/opt/workspace/transterra/dev/bundles/rock