### PR TITLE
Improve rock hz

### DIFF
--- a/bin/rock-hz
+++ b/bin/rock-hz
@@ -3,12 +3,20 @@
 require 'optparse'
 require 'orocos'
 
-options = Hash[buffersize: 1000, pull: false]
+policy = Hash[type: :buffer, size: 1000, pull: false]
+one_s_progress = [nil]
+ten_s_progress = [nil]
+options = Hash.new
 optparse = OptionParser.new do |opts|
     opts.banner = "usage: rock-hz -t <task-name> -p <port-name>"
 
     opts.on('--host=HOST', String) do |host|
         Orocos::CORBA.name_service.ip = host
+    end
+
+    opts.on('-c COUNT', '--count=COUNT', Integer) do |count|
+        one_s_progress = [nil] * count
+        ten_s_progress = [nil] * count
     end
 
     opts.on("-t","--task TASK","task name") do |t|
@@ -19,11 +27,12 @@ optparse = OptionParser.new do |opts|
         options[:port_name] = p
     end
 
-    opts.on("-b","--buffersize BUFFERSIZE","buffersize") do |size|
-        options[:buffersize] = size.to_i
+    opts.on("-b","--buffersize BUFFERSIZE",Integer,"buffersize") do |size|
+        policy[:type] = :buffer
+        policy[:size] = Integer(size)
     end
     opts.on '--pull', 'use a pull connection' do
-        options[:pull] = true
+        policy[:pull] = true
     end
 
     opts.on_tail("-h","--help", "Show this message") do
@@ -31,19 +40,19 @@ optparse = OptionParser.new do |opts|
         exit
     end
 end
-optparse.parse!
+task_name, port_name = optparse.parse(ARGV)
 
-if !(options[:task_name] || options[:port_name])
-    puts optparse
-    exit
+require 'rock/cli'
+require 'tty-cursor'
+require 'tty-table'
+Orocos.initialize
+port = Rock::CLI.choose_orocos_task_and_port(
+    task_name: options[:task_name] || task_name, port_name: options[:port_name] || port_name)
+if !port
+    exit 1
 end
 
-Orocos.initialize
-
-task = Orocos.get options[:task_name]
-port = task.port options[:port_name]
-port_reader = port.reader type: :buffer, size: options[:buffersize],
-    pull: options[:pull]
+port_reader = port.reader(**policy)
 
 min_reporting_period = 1
 def compute_frequency(now, queue, window_duration)
@@ -59,6 +68,17 @@ def compute_frequency(now, queue, window_duration)
         0
     end
 end
+
+msg_header = ["Message Frequencies"]
+if one_s_progress.size != 1
+    msg_header.concat(one_s_progress.size.times.map { |i| "t-#{i}" })
+else
+    msg_header << ""
+end
+
+puts
+puts
+cursor = TTY::Cursor
 
 begin
     one_s_queue = []
@@ -79,12 +99,27 @@ begin
         one_s = compute_frequency(now, one_s_queue, 1)
         ten_s = compute_frequency(now, ten_s_queue, 10)
 
-        # Terminal code to go up 1 line and clear the line
-        puts "message frequency (past 1 second): #{one_s}"
-        puts "message frequency (past 10 second): #{ten_s}"
+        cursor.restore
+
+        one_s_progress.unshift one_s
+        ten_s_progress.unshift ten_s
+        one_s_progress.pop
+        ten_s_progress.pop
+
+        print cursor.prev_line
+        print cursor.prev_line
+        print cursor.clear_lines(3, :down)
+        print cursor.prev_line
+        print cursor.prev_line
+        table = TTY::Table.new(
+            header: msg_header,
+            rows: [["Past 1s", *one_s_progress.compact.map { |n| "%.1f" % [n] }],
+                   ["Past 10s", *ten_s_progress.compact.map { |n| "%.1f" % [n] }]])
+        print table.render(:basic)
+
         if !has_new_samples
             sleep 0.1
         end
     end
-rescue SystemExit, Interrupt
+rescue Interrupt
 end

--- a/bin/rock-hz
+++ b/bin/rock-hz
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
 require 'optparse'
-options = {}
 
+options = Hash[buffersize: 1000, pull: false]
 optparse = OptionParser.new do |opts|
     opts.banner = "usage: rock-hz -t <task-name> -p <port-name>"
 
@@ -16,6 +16,9 @@ optparse = OptionParser.new do |opts|
 
     opts.on("-b","--buffersize BUFFERSIZE","buffersize") do |size|
         options[:buffersize] = size.to_i
+    end
+    opts.on '--pull', 'use a pull connection' do
+        options[:pull] = true
     end
 
     opts.on_tail("-h","--help", "Show this message") do
@@ -35,52 +38,49 @@ Orocos.initialize
 
 task = Orocos.get options[:task_name]
 port = task.port options[:port_name]
-buffersize = options[:buffersize] || 1000
-port_reader = port.reader :type => :buffer, :size => buffersize
+port_reader = port.reader type: :buffer, size: options[:buffersize],
+    pull: options[:pull]
 
-queue = []
-max_queue_size = 10
-one_s_counter = 0
-one_s_timer = Time.now
-progress_message = nil
+min_reporting_period = 1
+def compute_frequency(now, queue, window_duration)
+    return 0 if queue.empty?
+
+    deadline = now - window_duration
+    while !queue.empty? && (queue.last < deadline)
+        queue.pop
+    end
+    if !queue.empty?
+        Float(queue.size) / (now - queue.last)
+    else
+        0
+    end
+end
 
 begin
+    one_s_queue = []
+    one_s_filled = false
+    ten_s_queue = []
+    ten_s_filled = false
+
     while true
-            sample_counter = 0
-            while port_reader.read_new && (Time.now - one_s_timer) < 1
-                sample_counter += 1
-                if sample_counter > buffersize
-                    msg = "\nPlease increase buffer size (using option '-b') since it is likely overflown.\n"
-                    msg += "     - current buffer size: #{buffersize}\n"
-                    msg += "     - samples read in less than a second: #{sample_counter}"
-                    puts msg
-                    exit -1
-                end
-                one_s_counter += 1
-            end
+        start_time  = Time.now
+        has_new_samples = false
+        while port_reader.read_new && (Time.now - start_time) < min_reporting_period
+            has_new_samples = true
+            one_s_queue.unshift Time.now
+            ten_s_queue.unshift Time.now
+        end
 
-            if queue.size != max_queue_size || ! (ten_s_frequency = queue.reduce(:+)/10)
-                ten_s_frequency = "n/a"
-            end
+        now = Time.now
+        one_s = compute_frequency(now, one_s_queue, 1)
+        ten_s = compute_frequency(now, ten_s_queue, 10)
 
-            # Terminal code to go up 1 line and clear the line
-            print "\r" + ("\e[A\e[K"*2) if progress_message
-
-            progress_message = "message frequency (past 1 second):     #{one_s_counter}\n"
-            progress_message += "message frequency (past 10 seconds):   #{ten_s_frequency}"
-            puts "#{progress_message}"
-
-
-            if (Time.now - one_s_timer) > 1
-                if queue.size == max_queue_size
-                    queue.pop
-                end
-                queue.push one_s_counter
-                one_s_counter = 0
-                one_s_timer = Time.now
-            end
-
+        # Terminal code to go up 1 line and clear the line
+        puts "message frequency (past 1 second): #{one_s}"
+        puts "message frequency (past 10 second): #{ten_s}"
+        if !has_new_samples
             sleep 0.1
+        end
     end
 rescue SystemExit, Interrupt
 end

--- a/bin/rock-hz
+++ b/bin/rock-hz
@@ -1,10 +1,15 @@
 #!/usr/bin/env ruby
 
 require 'optparse'
+require 'orocos'
 
 options = Hash[buffersize: 1000, pull: false]
 optparse = OptionParser.new do |opts|
     opts.banner = "usage: rock-hz -t <task-name> -p <port-name>"
+
+    opts.on('--host=HOST', String) do |host|
+        Orocos::CORBA.name_service.ip = host
+    end
 
     opts.on("-t","--task TASK","task name") do |t|
         options[:task_name] = t
@@ -33,7 +38,6 @@ if !(options[:task_name] || options[:port_name])
     exit
 end
 
-require 'orocos'
 Orocos.initialize
 
 task = Orocos.get options[:task_name]

--- a/lib/rock/cli.rb
+++ b/lib/rock/cli.rb
@@ -1,0 +1,46 @@
+require 'tty-prompt'
+
+module Rock
+    module CLI
+        def self.choose_orocos_task_and_port(name_service: Orocos.name_service, task_name: nil, port_name: nil)
+            prompt = TTY::Prompt.new
+
+            if task_name
+                begin
+                    selected_task = Orocos.get(task_name)
+                rescue Orocos::NotFound
+                end
+                candidates = name_service.names.grep(/(^|\/)#{task_name}/)
+                if candidates.empty?
+                    STDERR.puts "No task matches #{task_name}, and none start with #{task_name}"
+                    return
+                end
+                if candidates.size == 1
+                    task_name = candidates.first
+                else
+                    task_name = prompt.select("Select a task", candidates)
+                end
+            end
+
+            if !task_name
+                tasks = name_service.names
+                if tasks.empty?
+                    STDERR.puts "No tasks available"
+                    return
+                end
+                task_name = prompt.select("Select a task", tasks)
+            end
+            selected_task ||= Orocos.get(task_name)
+
+            if !port_name
+                ports = selected_task.each_port.
+                    find_all { |p| p.respond_to?(:reader) }
+                ports = Hash[ports.map { |p| [p.name, p] }]
+                prompt.select("Select a port", ports)
+            else
+                selected_task.port(port_name)
+            end
+        end
+    end
+end
+

--- a/manifest.xml
+++ b/manifest.xml
@@ -8,6 +8,9 @@
   <depend package="thor" />
   <depend package="hoe" />
   <depend package="hoe-yard" />
+  <depend package="tty-prompt" />
+  <depend package="tty-cursor" />
+  <depend package="tty-table" />
 
   <test_depend package="flexmock" />
   <test_depend package="minitest" />


### PR DESCRIPTION
Depends on https://github.com/rock-core/package_set/pull/106

This fixes the way rock-hz was doing its averaging (which was really not working well), and adds the --host option.

In addition, it improves the UI:
 - without arguments, or if the given task/port do not match an existing
   one, the script now lists matching tasks/ports and lets the user
   choose one. This is currently buggy if there is more tasks than
   one page, but IMO it's still much better than the current situation
   of having to figure out task and port names and type them.
 - the display uses the TTY gem instead of hardcoding ANSI
   codes, and formats the output as a table without having a running
   console
 - with the -c COUNT option, it shows a history of the values