### PR TITLE
rock-run: Initialize bundles prior to calling the options parser

### DIFF
--- a/bin/rock-run
+++ b/bin/rock-run
@@ -27,6 +27,11 @@ end
 do_start = false
 do_log = false
 
+require 'orocos'
+require 'orocos/scripts'
+require 'orocos/async'
+Rock::Bundles.initialize
+
 parser = OptionParser.new
 Orocos::Scripts.common_optparse_setup(parser)
 parser.banner = "rock-run [--gui] task_model task_name"
@@ -39,13 +44,9 @@ end
 
 model, name = parser.parse(ARGV)
 
-require 'orocos'
 if Orocos::Scripts.gui?
     require 'vizkit'
 end
-require 'orocos/scripts'
-
-Rock::Bundles.initialize
 
 if !name
     if model =~ /::/


### PR DESCRIPTION
`Rock::Bundles.initialize` must be called otherwise Orocos.conf returns nil thus breaking `--conf-dir` option