### PR TITLE
Recursively load all transformer configurations.

### DIFF
--- a/lib/rock/bundles.rb
+++ b/lib/rock/bundles.rb
@@ -360,7 +360,7 @@ module Rock
                 require 'transformer/runtime'
                 Transformer.use_bundle_loader
                 @transformer_config ||= "transforms.rb"
-                if conf_file = find_file('config', @transformer_config, :order => :specific_first)
+                find_files('config', @transformer_config, :order => :specific_last, :all => true).each do |conf_file|
                     Orocos.transformer.load_conf(conf_file)
                 end
             rescue LoadError


### PR DESCRIPTION
Currently configuration files are loaded recursively from all bundles, but the transformer configuration is only loaded from the most specific bundle. I would suggest to handle the transformer configuration in the same way as the orogen configs. 

Not sure what the intended behavior is though. The suggested change will definitely change that behavior and probably cause issues when an previously unused transforms.rb is present in an included bundle.