### PR TITLE
rock-browse: fix display of package_sets

### DIFF
--- a/lib/rock/html/autoproj_package_set.rb
+++ b/lib/rock/html/autoproj_package_set.rb
@@ -8,7 +8,7 @@ module Rock
                 @template = page.load_template(TEMPLATE_DIR, 'autoproj_package_set.page')
             end
 
-            def render(pkg_set)
+            def render(info, pkg_set)
                 page.push nil, template.result(binding)
             end
 


### PR DESCRIPTION
When selecting a pagkage_set, rock-browse chrashed (see error message below).
This fixes the rendering.
```bash
devel@splanthaber-u:/opt/workspace$ rock-browse
/usr/lib/ruby/2.5.0/net/protocol.rb:66: warning: already initialized constant Net::ProtocRetryError
/home/devel/.local/share/autoproj/gems/ruby/2.5.0/gems/net-protocol-0.1.1/lib/net/protocol.rb:68: warning: previous definition of ProtocRetryError was here
/usr/lib/ruby/2.5.0/net/protocol.rb:172: warning: already initialized constant Net::BufferedIO::BUFSIZE
/home/devel/.local/share/autoproj/gems/ruby/2.5.0/gems/net-protocol-0.1.1/lib/net/protocol.rb:208: warning: previous definition of BUFSIZE was here
/usr/lib/ruby/2.5.0/net/protocol.rb:439: warning: already initialized constant Net::NetPrivate::Socket
/home/devel/.local/share/autoproj/gems/ruby/2.5.0/gems/net-protocol-0.1.1/lib/net/protocol.rb:505: warning: previous definition of Socket was here
WARN: integrating typelib plugin using the TYPELIB_RUBY_PLUGIN_PATH environment variable is deprecated
WARN: just put a file called typelib_plugin.rb into a subfolder from the RUBYLIB (e.g. base/typelib_plugin.rb)
WARN: offending dir: /opt/workspace/install/share/typelib/ruby
Traceback (most recent call last):
	8: from /opt/workspace/base/scripts/bin/rock-browse:32:in `<main>'
	7: from /home/devel/.local/share/autoproj/gems/ruby/2.5.0/gems/qtbindings-4.8.6.5/lib/Qt/qtruby4.rb:479:in `exec'
	6: from /home/devel/.local/share/autoproj/gems/ruby/2.5.0/gems/qtbindings-4.8.6.5/lib/Qt/qtruby4.rb:479:in `method_missing'
	5: from /home/devel/.local/share/autoproj/gems/ruby/2.5.0/gems/qtbindings-4.8.6.5/lib/Qt/qtruby4.rb:479:in `qt_metacall'
	4: from /home/devel/.local/share/autoproj/gems/ruby/2.5.0/gems/qtbindings-4.8.6.5/lib/Qt/qtruby4.rb:2470:in `invoke'
	3: from /opt/workspace/base/scripts/lib/rock/browse/main.rb:80:in `block in create_ui'
	2: from /opt/workspace/base/scripts/lib/rock/browse/main.rb:96:in `render_item'
	1: from /opt/workspace/base/scripts/lib/rock/browse/main.rb:118:in `render'
/opt/workspace/base/scripts/lib/rock/html/autoproj_package_set.rb:11:in `render': wrong number of arguments (given 2, expected 1) (ArgumentError)
devel@splanthaber-u:/opt/workspace$ rock-browse
/usr/lib/ruby/2.5.0/net/protocol.rb:66: warning: already initialized constant Net::ProtocRetryError
/home/devel/.local/share/autoproj/gems/ruby/2.5.0/gems/net-protocol-0.1.1/lib/net/protocol.rb:68: warning: previous definition of ProtocRetryError was here
/usr/lib/ruby/2.5.0/net/protocol.rb:172: warning: already initialized constant Net::BufferedIO::BUFSIZE
/home/devel/.local/share/autoproj/gems/ruby/2.5.0/gems/net-protocol-0.1.1/lib/net/protocol.rb:208: warning: previous definition of BUFSIZE was here
/usr/lib/ruby/2.5.0/net/protocol.rb:439: warning: already initialized constant Net::NetPrivate::Socket
/home/devel/.local/share/autoproj/gems/ruby/2.5.0/gems/net-protocol-0.1.1/lib/net/protocol.rb:505: warning: previous definition of Socket was here
WARN: integrating typelib plugin using the TYPELIB_RUBY_PLUGIN_PATH environment variable is deprecated
WARN: just put a file called typelib_plugin.rb into a subfolder from the RUBYLIB (e.g. base/typelib_plugin.rb)
WARN: offending dir: /opt/workspace/install/share/typelib/ruby
Traceback (most recent call last):
	8: from /opt/workspace/base/scripts/bin/rock-browse:32:in `<main>'
	7: from /home/devel/.local/share/autoproj/gems/ruby/2.5.0/gems/qtbindings-4.8.6.5/lib/Qt/qtruby4.rb:479:in `exec'
	6: from /home/devel/.local/share/autoproj/gems/ruby/2.5.0/gems/qtbindings-4.8.6.5/lib/Qt/qtruby4.rb:479:in `method_missing'
	5: from /home/devel/.local/share/autoproj/gems/ruby/2.5.0/gems/qtbindings-4.8.6.5/lib/Qt/qtruby4.rb:479:in `qt_metacall'
	4: from /home/devel/.local/share/autoproj/gems/ruby/2.5.0/gems/qtbindings-4.8.6.5/lib/Qt/qtruby4.rb:2470:in `invoke'
	3: from /opt/workspace/base/scripts/lib/rock/browse/main.rb:80:in `block in create_ui'
	2: from /opt/workspace/base/scripts/lib/rock/browse/main.rb:96:in `render_item'
	1: from /opt/workspace/base/scripts/lib/rock/browse/main.rb:118:in `render'
/opt/workspace/base/scripts/lib/rock/html/autoproj_package_set.rb:11:in `render': wrong number of arguments (given 2, expected 1) (ArgumentError)

```